### PR TITLE
add multiple routes and versions support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,27 +10,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0, 8.1, 8.2]
-                laravel: [8.*, 9.*, 10.*]
+                php: [8.1, 8.2]
+                laravel: [9.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 exclude:
                     -   php: 8.2
                         laravel: 9.*
                         dependency-version: prefer-lowest
-                    -   php: 8.2
-                        laravel: 8.*
-                    -   php: 8.1
-                        laravel: 8.*
-                        dependency-version: prefer-lowest
-                    -   php: 8.0
-                        laravel: 10.*
-                    -   php: 8.0
-                        laravel: 8.*
-                        dependency-version: prefer-lowest
-                    -   php: 7.4
-                        laravel: 9.*
-                    -   php: 7.4
-                        laravel: 10.*
 
         name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ protected function gate()
 ```
 
 In the published `config/swagger-ui.php` file, you edit the path to the Swagger UI and the location of the Swagger (OpenAPI v3) file. By default, the package expects to find the OpenAPI file in 'resources/swagger' directory. You can also provide an url if the OpenAPI file is not present in the Laravel project itself.
+This is also where you can define multiple versions for the same api.
 
 ```php
 // in config/swagger-ui.php
@@ -53,7 +54,9 @@ return [
 
     'path' => 'swagger',
 
-    'file' => resource_path('swagger/openapi.json'),
+    'versions' => [
+        'v1' => resource_path('swagger/openapi.json')
+    ],
 
     // ...
 ];

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1|^8.2",
+        "php": "^8.1|^8.2",
         "ext-json": "*",
-        "laravel/framework": "^8.0|^9.0|^10.0"
+        "laravel/framework": "^9.0|^10.0"
     },
     "suggest": {
         "ext-yaml": "*"

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
+        "jasonmccreary/laravel-test-assertions": "^2.3",
         "orchestra/testbench": "^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^9.1",
         "squizlabs/php_codesniffer": "^3.6"

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -31,6 +31,11 @@ return [
             ],
 
             /*
+             * If enabled the file will be modified to set the server url and oauth urls.
+             */
+            'modify_file' => true,
+
+            /*
              * The oauth configuration for the swagger file.
              */
             'oauth' => [
@@ -41,11 +46,6 @@ return [
                 'client_id' => env('SWAGGER_UI_OAUTH_CLIENT_ID'),
                 'client_secret' => env('SWAGGER_UI_OAUTH_CLIENT_SECRET'),
             ],
-
-            /*
-             * If enabled the file will be modified to set the server url and oauth urls.
-             */
-            'modify_file' => true,
         ],
     ],
 ];

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -3,73 +3,49 @@
 use NextApps\SwaggerUi\Http\Middleware\EnsureUserIsAuthorized;
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Swagger UI - Path
-    |--------------------------------------------------------------------------
-    |
-    | This is the URI path where SwaggerUI will be accessible from. Feel free
-    | to change this path to anything you like.
-    |
-    */
+    'files' => [
+        [
+            /*
+             * The path where the swagger file is served.
+             */
+            'path' => 'swagger',
 
-    'path' => 'swagger',
+            /*
+             * The versions of the swagger file. The key is the version name and the value is the path to the file.
+             */
+            'versions' => [
+                'v1' => resource_path('swagger/openapi.json'),
+            ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Swagger UI - Route Middleware
-    |--------------------------------------------------------------------------
-    |
-    | These middleware will be assigned to every Swagger UI route.
-    |
-    */
+            /*
+             * The default version that is loaded when the route is accessed.
+             */
+            'default' => 'v1',
 
-    'middleware' => [
-        'web',
-        EnsureUserIsAuthorized::class,
-    ],
+            /*
+             * The middleware that is applied to the route.
+             */
+            'middleware' => [
+                'web',
+                EnsureUserIsAuthorized::class,
+            ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Swagger UI - OpenAPI File
-    |--------------------------------------------------------------------------
-    |
-    | This is the location of the project's OpenAPI / Swagger JSON file. It's
-    | this file that will be used in Swagger UI. This can either be a local
-    | file or an url to a file.
-    |
-    */
+            /*
+             * The oauth configuration for the swagger file.
+             */
+            'oauth' => [
+                'token_path' => 'oauth/token',
+                'refresh_path' => 'oauth/token',
+                'authorization_path' => 'oauth/authorize',
 
-    'file' => resource_path('swagger/openapi.json'),
+                'client_id' => env('SWAGGER_UI_OAUTH_CLIENT_ID'),
+                'client_secret' => env('SWAGGER_UI_OAUTH_CLIENT_SECRET'),
+            ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Swagger UI - Modify File
-    |--------------------------------------------------------------------------
-    |
-    | If this option is enabled, then the file will be changed before it is
-    | used by Swagger UI. The server url and oauth urls will be changed to
-    | the base url of this Laravel application.
-    |
-    */
-
-    'modify_file' => true,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Swagger UI - OAuth Config
-    |--------------------------------------------------------------------------
-    |
-    | This allows you to configure oauth within Swagger UI. It makes it easier
-    | to authenticate in Swagger UI by prefilling certain values.
-    |
-    */
-    'oauth' => [
-        'token_path' => 'oauth/token',
-        'refresh_path' => 'oauth/token',
-        'authorization_path' => 'oauth/authorize',
-
-        'client_id' => env('SWAGGER_UI_OAUTH_CLIENT_ID'),
-        'client_secret' => env('SWAGGER_UI_OAUTH_CLIENT_SECRET'),
+            /*
+             * If enabled the file will be modified to set the server url and oauth urls.
+             */
+            'modify_file' => true,
+        ],
     ],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "laravel-swagger-ui",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -27,22 +27,32 @@
         <div id="swagger-ui"></div>
 
         <script src="https://unpkg.com/swagger-ui-dist@latest/swagger-ui-bundle.js"></script>
+        <script src="https://unpkg.com/swagger-ui-dist@latest/swagger-ui-standalone-preset.js"></script>
 
         <script>
             window.onload = function () {
                 window.ui = SwaggerUIBundle({
-                    url: '{{ route('swagger-openapi-json', [], false) }}',
+                    urls: [
+                        @foreach ($data['versions'] as $version => $path)
+                            {
+                                url: '{{ ltrim($data['path'], '/') . '/' . $version }}',
+                                name: '{{ $version }}',
+                            },
+                        @endforeach
+                    ],
+                    "urls.primaryName": "{{$data['default']}}",
                     dom_id: '#swagger-ui',
                     deepLinking: true,
                     presets: [
                         SwaggerUIBundle.presets.apis,
+                        SwaggerUIStandalonePreset
                     ],
-                    layout: 'BaseLayout',
+                    layout: 'StandaloneLayout',
                 });
 
                 ui.initOAuth({
-                    clientId: '{{ config('swagger-ui.oauth.client_id') }}',
-                    clientSecret: '{{ config('swagger-ui.oauth.client_secret') }}',
+                    clientId: '{{ $data['oauth']['client_id'] }}',
+                    clientSecret: '{{ $data['oauth']['client_secret'] }}',
                 });
             };
         </script>

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -19,7 +19,7 @@ class OpenApiJsonController
             $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($filename, $path) {
                 return isset($values['versions'][$filename]) && ltrim($values['path'], '/') === $path;
             })->firstOrFail();
-        } catch (ItemNotFoundException $e) {
+        } catch (ItemNotFoundException) {
             return abort(404);
         }
 

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -3,20 +3,19 @@
 namespace NextApps\SwaggerUi\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use RuntimeException;
 
 class OpenApiJsonController
 {
-    public function __invoke(string $path, string $filename) : JsonResponse
+    public function __invoke(Request $request, string $filename) : JsonResponse
     {
+        $path = $request->segment(1);
+
         $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($filename, $path) {
             return isset($values['versions'][$filename]) && ltrim($values['path'], '/') === $path;
-        })->first();
-
-        if (empty($file)) {
-            abort(404);
-        }
+        })->firstOrFail();
 
         $json = $this->getJson($file['versions'][$filename]);
 

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -8,19 +8,26 @@ use RuntimeException;
 
 class OpenApiJsonController
 {
-    public function __invoke() : JsonResponse
+    public function __invoke(string $path, string $filename) : JsonResponse
     {
-        $json = $this->getJson();
+        $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($filename, $path) {
+            return isset($values['versions'][$filename]) && ltrim($values['path'], '/') === $path;
+        })->first();
 
-        $json = $this->configureServer($json);
-        $json = $this->configureOAuth($json);
+        if (empty($file)) {
+            abort(404);
+        }
+
+        $json = $this->getJson($file['versions'][$filename]);
+
+        $json = $this->configureServer($file, $json);
+        $json = $this->configureOAuth($file, $json);
 
         return response()->json($json);
     }
 
-    protected function getJson() : array
+    protected function getJson(string $path) : array
     {
-        $path = config('swagger-ui.file');
         $content = file_get_contents($path);
 
         if (Str::endsWith($path, '.yaml')) {
@@ -34,9 +41,9 @@ class OpenApiJsonController
         return json_decode($content, true);
     }
 
-    protected function configureServer(array $json) : array
+    protected function configureServer(array $file, array $json) : array
     {
-        if (! config('swagger-ui.modify_file')) {
+        if (! $file['modify_file']) {
             return $json;
         }
 
@@ -47,28 +54,28 @@ class OpenApiJsonController
         return $json;
     }
 
-    protected function configureOAuth(array $json) : array
+    protected function configureOAuth(array $file, array $json) : array
     {
-        if (empty($json['components']['securitySchemes']) || ! config('swagger-ui.modify_file')) {
+        if (empty($json['components']['securitySchemes']) || ! $file['modify_file']) {
             return $json;
         }
 
-        $securitySchemes = collect($json['components']['securitySchemes'])->map(function ($scheme) {
+        $securitySchemes = collect($json['components']['securitySchemes'])->map(function ($scheme) use ($file) {
             if ($scheme['type'] !== 'oauth2') {
                 return $scheme;
             }
 
-            $scheme['flows'] = collect($scheme['flows'])->map(function ($flow) {
+            $scheme['flows'] = collect($scheme['flows'])->map(function ($flow) use ($file) {
                 if (isset($flow['tokenUrl'])) {
-                    $flow['tokenUrl'] = url(config('swagger-ui.oauth.token_path'));
+                    $flow['tokenUrl'] = url($file['oauth']['token_path']);
                 }
 
                 if (isset($flow['refreshUrl'])) {
-                    $flow['refreshUrl'] = url(config('swagger-ui.oauth.refresh_path'));
+                    $flow['refreshUrl'] = url($file['oauth']['refresh_path']);
                 }
 
                 if (isset($flow['authorizationUrl'])) {
-                    $flow['authorizationUrl'] = url(config('swagger-ui.oauth.authorization_path'));
+                    $flow['authorizationUrl'] = url($file['oauth']['authorization_path']);
                 }
 
                 return $flow;

--- a/src/Http/Controllers/SwaggerViewController.php
+++ b/src/Http/Controllers/SwaggerViewController.php
@@ -13,8 +13,8 @@ class SwaggerViewController
             $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($request) {
                 return ltrim($values['path'], '/') === $request->path();
             })->firstOrFail();
-        } catch (ItemNotFoundException $e) {
-            return response()->json(['error' => 'File not found'], 404);
+        } catch (ItemNotFoundException) {
+            return abort(404);
         }
 
         return view('swagger-ui::index', ['data' => collect($file)]);

--- a/src/Http/Controllers/SwaggerViewController.php
+++ b/src/Http/Controllers/SwaggerViewController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NextApps\SwaggerUi\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class SwaggerViewController
+{
+    public function __invoke(Request $request)
+    {
+        $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($request) {
+            return ltrim($values['path'], '/') === $request->path();
+        })->first();
+
+        return view('swagger-ui::index', ['data' => collect($file)]);
+    }
+}

--- a/src/Http/Controllers/SwaggerViewController.php
+++ b/src/Http/Controllers/SwaggerViewController.php
@@ -3,14 +3,19 @@
 namespace NextApps\SwaggerUi\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\ItemNotFoundException;
 
 class SwaggerViewController
 {
     public function __invoke(Request $request)
     {
-        $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($request) {
-            return ltrim($values['path'], '/') === $request->path();
-        })->firstOrFail();
+        try {
+            $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($request) {
+                return ltrim($values['path'], '/') === $request->path();
+            })->firstOrFail();
+        } catch (ItemNotFoundException $e) {
+            return response()->json(['error' => 'File not found'], 404);
+        }
 
         return view('swagger-ui::index', ['data' => collect($file)]);
     }

--- a/src/Http/Controllers/SwaggerViewController.php
+++ b/src/Http/Controllers/SwaggerViewController.php
@@ -10,7 +10,7 @@ class SwaggerViewController
     {
         $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($request) {
             return ltrim($values['path'], '/') === $request->path();
-        })->first();
+        })->firstOrFail();
 
         return view('swagger-ui::index', ['data' => collect($file)]);
     }

--- a/src/SwaggerUiServiceProvider.php
+++ b/src/SwaggerUiServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Support\ServiceProvider;
 use NextApps\SwaggerUi\Console\InstallCommand;
 use NextApps\SwaggerUi\Http\Controllers\OpenApiJsonController;
 use NextApps\SwaggerUi\Http\Controllers\SwaggerViewController;
-use NextApps\SwaggerUi\Http\Middleware\EnsureUserIsAuthorized;
 
 class SwaggerUiServiceProvider extends ServiceProvider
 {
@@ -38,11 +37,11 @@ class SwaggerUiServiceProvider extends ServiceProvider
     protected function loadRoutes() : void
     {
         collect(config('swagger-ui.files'))->each(function ($values) {
-            Route::middleware($values['middleware'] ?? ['web', EnsureUserIsAuthorized::class])
+            Route::middleware($values['middleware'])
                 ->group(function () use ($values) {
-                    Route::get(ltrim($values['path'], '/'), SwaggerViewController::class);
+                    Route::get($values['path'], SwaggerViewController::class)->name($values['path'] . '.index');
 
-                    Route::get('{path}/{filename}', OpenApiJsonController::class);
+                    Route::get($values['path'] . '/{filename}', OpenApiJsonController::class)->name($values['path'] . '.json');
                 });
         });
     }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace NextApps\SwaggerUi\Test;
+namespace NextApps\SwaggerUi\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Gate;
 use NextApps\SwaggerUi\SwaggerUiServiceProvider;
-use Orchestra\Testbench\TestCase;
 
 class AuthorizationTest extends TestCase
 {
@@ -13,7 +12,7 @@ class AuthorizationTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('swagger-ui.file', __DIR__ . '/testfiles/openapi.json');
+        config()->set('swagger-ui.files.0.versions', ['v1' => __DIR__ . '/testfiles/openapi.json']);
     }
 
     protected function getPackageProviders($app) : array
@@ -25,7 +24,7 @@ class AuthorizationTest extends TestCase
     public function it_denies_access_in_default_installation()
     {
         $this->get('swagger')->assertStatus(403);
-        $this->get('swagger/openapi.json')->assertStatus(403);
+        $this->get('swagger/v1')->assertStatus(403);
     }
 
     /** @test */
@@ -34,7 +33,7 @@ class AuthorizationTest extends TestCase
         $this->actingAs(new Authenticated());
 
         $this->get('swagger')->assertStatus(403);
-        $this->get('swagger/openapi.json')->assertStatus(403);
+        $this->get('swagger/v1')->assertStatus(403);
     }
 
     /** @test */
@@ -43,7 +42,7 @@ class AuthorizationTest extends TestCase
         Gate::define('viewSwaggerUI', fn () => true);
 
         $this->get('swagger')->assertStatus(403);
-        $this->get('swagger/openapi.json')->assertStatus(403);
+        $this->get('swagger/v1')->assertStatus(403);
     }
 
     /** @test */
@@ -56,7 +55,7 @@ class AuthorizationTest extends TestCase
         });
 
         $this->get('swagger')->assertStatus(200);
-        $this->get('swagger/openapi.json')->assertStatus(200);
+        $this->get('swagger/v1')->assertStatus(200);
     }
 
     /** @test */
@@ -67,7 +66,7 @@ class AuthorizationTest extends TestCase
         Gate::define('viewSwaggerUI', fn () => false);
 
         $this->get('swagger')->assertStatus(403);
-        $this->get('swagger/openapi.json')->assertStatus(403);
+        $this->get('swagger/v1')->assertStatus(403);
     }
 
     /** @test */
@@ -76,7 +75,7 @@ class AuthorizationTest extends TestCase
         Gate::define('viewSwaggerUI', fn (?Authenticated $user) => true);
 
         $this->get('swagger')->assertStatus(200);
-        $this->get('swagger/openapi.json')->assertStatus(200);
+        $this->get('swagger/v1')->assertStatus(200);
     }
 }
 

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -27,10 +27,6 @@ class OpenApiRouteTest extends TestCase
         return [
             'json file' => [__DIR__ . '/testfiles/openapi.json'],
             'yaml file' => [__DIR__ . '/testfiles/openapi.yaml'],
-            'multiple versions' => [
-                'v1' => __DIR__ . '/testfiles/openapi.json',
-                'v2' => __DIR__ . '/testfiles/openapi.yaml',
-            ],
         ];
     }
 

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -30,7 +30,7 @@ class OpenApiRouteTest extends TestCase
             'multiple versions' => [
                 'v1' => __DIR__ . '/testfiles/openapi.json',
                 'v2' => __DIR__ . '/testfiles/openapi.yaml',
-            ]
+            ],
         ];
     }
 

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace NextApps\SwaggerUi\Test;
+namespace NextApps\SwaggerUi\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Gate;
 use NextApps\SwaggerUi\SwaggerUiServiceProvider;
-use Orchestra\Testbench\TestCase;
 
 class OpenApiRouteTest extends TestCase
 {
@@ -13,7 +12,7 @@ class OpenApiRouteTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('swagger-ui.file', __DIR__ . '/testfiles/openapi.json');
+        config()->set('swagger-ui.files.0.versions', ['v1' => __DIR__ . '/testfiles/openapi.json']);
 
         Gate::define('viewSwaggerUI', fn (?Authenticatable $user) => true);
     }
@@ -28,6 +27,10 @@ class OpenApiRouteTest extends TestCase
         return [
             'json file' => [__DIR__ . '/testfiles/openapi.json'],
             'yaml file' => [__DIR__ . '/testfiles/openapi.yaml'],
+            'multiple versions' => [
+                'v1' => __DIR__ . '/testfiles/openapi.json',
+                'v2' => __DIR__ . '/testfiles/openapi.yaml',
+            ]
         ];
     }
 
@@ -38,11 +41,11 @@ class OpenApiRouteTest extends TestCase
      */
     public function it_sets_server_to_current_app_url_if_modify_file_is_enabled($openApiFile)
     {
-        config()->set('swagger-ui.file', $openApiFile);
-        config()->set('swagger-ui.modify_file', true);
+        config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
+        config()->set('swagger-ui.files.0.modify_file', true);
         config()->set('app.url', 'http://foo.bar');
 
-        $this->get('swagger/openapi.json')
+        $this->get('swagger/v1')
             ->assertStatus(200)
             ->assertJsonCount(1, 'servers')
             ->assertJsonPath('servers.0.url', 'http://foo.bar');
@@ -55,13 +58,11 @@ class OpenApiRouteTest extends TestCase
      */
     public function it_sets_oauth_urls_by_combining_configured_paths_with_current_app_url_if_modify_file_is_enabled($openApiFile)
     {
-        config()->set('swagger-ui.file', $openApiFile);
-        config()->set('swagger-ui.modify_file', true);
-        config()->set('swagger-ui.oauth.token_path', 'this-is-token-path');
-        config()->set('swagger-ui.oauth.refresh_path', 'this-is-refresh-path');
-        config()->set('swagger-ui.oauth.authorization_path', 'this-is-authorization-path');
+        config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
+        config()->set('swagger-ui.files.0.modify_file', true);
+        config()->set('swagger-ui.files.0.oauth', ['token_path' => 'this-is-token-path', 'refresh_path' => 'this-is-refresh-path', 'authorization_path' => 'this-is-authorization-path']);
 
-        $this->get('swagger/openapi.json')
+        $this->get('swagger/v1')
             ->assertStatus(200)
             ->assertJsonPath('components.securitySchemes.Foobar.flows.password.tokenUrl', 'http://localhost/this-is-token-path')
             ->assertJsonPath('components.securitySchemes.Foobar.flows.password.refreshUrl', 'http://localhost/this-is-refresh-path')
@@ -77,11 +78,12 @@ class OpenApiRouteTest extends TestCase
      */
     public function it_doesnt_sets_server_to_current_app_url_if_modify_file_is_disabled($openApiFile)
     {
-        config()->set('swagger-ui.file', $openApiFile);
-        config()->set('swagger-ui.modify_file', false);
+        config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
+        config()->set('swagger-ui.files.0.modify_file', false);
+
         config()->set('app.url', 'http://foo.bar');
 
-        $this->get('swagger/openapi.json')
+        $this->get('swagger/v1')
             ->assertStatus(200)
             ->assertJsonCount(1, 'servers')
             ->assertJsonPath('servers.0.url', 'http://localhost:3000');
@@ -94,13 +96,11 @@ class OpenApiRouteTest extends TestCase
      */
     public function it_doesnt_sets_oauth_urls_by_combining_configured_paths_with_current_app_url_if_modify_file_is_disabled($openApiFile)
     {
-        config()->set('swagger-ui.file', $openApiFile);
-        config()->set('swagger-ui.modify_file', false);
-        config()->set('swagger-ui.oauth.token_path', 'this-is-token-path');
-        config()->set('swagger-ui.oauth.refresh_path', 'this-is-refresh-path');
-        config()->set('swagger-ui.oauth.authorization_path', 'this-is-authorization-path');
+        config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
+        config()->set('swagger-ui.files.0.modify_file', false);
+        config()->set('swagger-ui.files.0.oauth', ['token_path' => 'this-is-token-path', 'refresh_path' => 'this-is-refresh-path', 'authorization_path' => 'this-is-authorization-path']);
 
-        $this->get('swagger/openapi.json')
+        $this->get('swagger/v1')
             ->assertStatus(200)
             ->assertJsonPath('components.securitySchemes.Foobar.flows.password.tokenUrl', 'http://localhost:3000/password/tokenUrl')
             ->assertJsonPath('components.securitySchemes.Foobar.flows.password.refreshUrl', 'http://localhost:3000/password/refreshUrl')

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -104,4 +104,25 @@ class OpenApiRouteTest extends TestCase
             ->assertJsonPath('components.securitySchemes.Foobar.flows.authorizationCode.tokenUrl', 'http://localhost:3000/authorizationCode/tokenUrl')
             ->assertJsonPath('components.securitySchemes.Foobar.flows.authorizationCode.refreshUrl', 'http://localhost:3000/authorizationCode/refreshUrl');
     }
+
+    /** @test */
+    public function it_returns_not_found_response_if_provided_version_does_not_exist_in_file()
+    {
+        $this->getJson('swagger/v4')
+            ->assertStatus(404);
+    }
+
+    /** @test */
+    public function it_returns_not_found_response_if_provided_file_does_not_exist()
+    {
+        $this->getJson('foo-bar/v1')
+            ->assertStatus(404);
+    }
+
+    /** @test */
+    public function it_returns_not_found_response_if_provided_route_does_not_exist()
+    {
+        $this->getJson('foo-bar')
+            ->assertStatus(404);
+    }
 }

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -113,7 +113,7 @@ class OpenApiRouteTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_not_found_response_if_provided_file_does_not_exist()
+    public function it_returns_not_found_response_if_provided_file_does_not_exist_even_when_provided_version_exists()
     {
         $this->getJson('foo-bar/v1')
             ->assertStatus(404);

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -4,6 +4,7 @@ namespace NextApps\SwaggerUi\Tests;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Gate;
+use NextApps\SwaggerUi\Http\Middleware\EnsureUserIsAuthorized;
 use NextApps\SwaggerUi\SwaggerUiServiceProvider;
 
 class SwaggerUiRouteTest extends TestCase
@@ -28,7 +29,7 @@ class SwaggerUiRouteTest extends TestCase
     {
         $this->get('swagger')
             ->assertStatus(200)
-            ->assertSee('url: \'' . 'swagger/v1' . '\'', false);
+            ->assertSee('url: \'swagger/v1\'', false);
     }
 
     /** @test */
@@ -41,19 +42,19 @@ class SwaggerUiRouteTest extends TestCase
     }
 
     /** @test */
-    public function it_allows_multiple_routes()
-    {
-        $this->get('swagger2')
-            ->assertStatus(200)
-            ->assertSee('url: \'' . 'swagger2/v1' . '\'', false);
-    }
-
-    /** @test */
     public function it_supports_multiple_verions()
     {
         $this->get('swagger-with-versions')
             ->assertStatus(200)
-            ->assertSee('url: \'' . 'swagger-with-versions/v1' . '\'', false)
-            ->assertSee('url: \'' . 'swagger-with-versions/v2' . '\'', false);
+            ->assertSee('url: \'swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'swagger-with-versions/v2\'', false);
+    }
+
+    /** @test */
+    public function it_applies_middleware_from_config()
+    {
+        $this->assertRouteUsesMiddleware('swagger.index', ['web', EnsureUserIsAuthorized::class]);
+
+        $this->assertRouteUsesMiddleware('swagger-with-versions.index', ['web']);
     }
 }

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -2,8 +2,8 @@
 
 namespace NextApps\SwaggerUi\Tests;
 
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Gate;
 use NextApps\SwaggerUi\SwaggerUiServiceProvider;
 
 class SwaggerUiRouteTest extends TestCase

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace NextApps\SwaggerUi\Test;
+namespace NextApps\SwaggerUi\Tests;
 
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
 use NextApps\SwaggerUi\SwaggerUiServiceProvider;
-use Orchestra\Testbench\TestCase;
 
 class SwaggerUiRouteTest extends TestCase
 {
@@ -13,7 +12,8 @@ class SwaggerUiRouteTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('swagger-ui.file', __DIR__ . '/testfiles/openapi.json');
+        config()->set('swagger-ui.files.0.versions', ['v1' => __DIR__ . '/testfiles/openapi.json']);
+        config()->set('swagger-ui.files.0.oauth', ['client_id' => 1, 'client_secret' => 'foobar']);
 
         Gate::define('viewSwaggerUI', fn (?Authenticatable $user) => true);
     }
@@ -26,23 +26,34 @@ class SwaggerUiRouteTest extends TestCase
     /** @test */
     public function it_provides_openapi_route_as_url()
     {
-        config()->set('swagger-ui.oauth.client_id', 1);
-        config()->set('swagger-ui.oauth.client_secret', 'foobar');
-
         $this->get('swagger')
             ->assertStatus(200)
-            ->assertSee('url: \'' . route('swagger-openapi-json', [], false) . '\'', false);
+            ->assertSee('url: \'' . 'swagger/v1' . '\'', false);
     }
 
     /** @test */
     public function it_fills_oauth_client_id_and_secret_from_config()
     {
-        config()->set('swagger-ui.oauth.client_id', 1);
-        config()->set('swagger-ui.oauth.client_secret', 'foobar');
-
         $this->get('swagger')
             ->assertStatus(200)
             ->assertSee('clientId: \'1\',', false)
             ->assertSee('clientSecret: \'foobar\',', false);
+    }
+
+    /** @test */
+    public function it_allows_multiple_routes()
+    {
+        $this->get('swagger2')
+            ->assertStatus(200)
+            ->assertSee('url: \'' . 'swagger2/v1' . '\'', false);
+    }
+
+    /** @test */
+    public function it_supports_multiple_verions()
+    {
+        $this->get('swagger-with-versions')
+            ->assertStatus(200)
+            ->assertSee('url: \'' . 'swagger-with-versions/v1' . '\'', false)
+            ->assertSee('url: \'' . 'swagger-with-versions/v2' . '\'', false);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NextApps\SwaggerUi\Tests;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('swagger-ui.files.1', config('swagger-ui.files.0'));
+        $app['config']->set('swagger-ui.files.1.oauth', ['client_id' => 1, 'client_secret' => 'foobar']);
+        $app['config']->set('swagger-ui.files.1.path', 'swagger2');
+
+        $app['config']->set('swagger-ui.files.2', config('swagger-ui.files.0'));
+        $app['config']->set('swagger-ui.files.2.versions', [
+            'v1' => __DIR__ . '/testfiles/openapi.json',
+            'v2' => __DIR__ . '/testfiles/openapi-v2.json'
+        ]);
+        $app['config']->set('swagger-ui.files.2.path', 'swagger-with-versions');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends BaseTestCase
         $app['config']->set('swagger-ui.files.2', config('swagger-ui.files.0'));
         $app['config']->set('swagger-ui.files.2.versions', [
             'v1' => __DIR__ . '/testfiles/openapi.json',
-            'v2' => __DIR__ . '/testfiles/openapi-v2.json'
+            'v2' => __DIR__ . '/testfiles/openapi-v2.json',
         ]);
         $app['config']->set('swagger-ui.files.2.path', 'swagger-with-versions');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,21 +2,21 @@
 
 namespace NextApps\SwaggerUi\Tests;
 
+use JMac\Testing\Traits\AdditionalAssertions;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
+    use AdditionalAssertions;
+
     protected function defineEnvironment($app)
     {
         $app['config']->set('swagger-ui.files.1', config('swagger-ui.files.0'));
-        $app['config']->set('swagger-ui.files.1.oauth', ['client_id' => 1, 'client_secret' => 'foobar']);
-        $app['config']->set('swagger-ui.files.1.path', 'swagger2');
-
-        $app['config']->set('swagger-ui.files.2', config('swagger-ui.files.0'));
-        $app['config']->set('swagger-ui.files.2.versions', [
+        $app['config']->set('swagger-ui.files.1.versions', [
             'v1' => __DIR__ . '/testfiles/openapi.json',
             'v2' => __DIR__ . '/testfiles/openapi-v2.json',
         ]);
-        $app['config']->set('swagger-ui.files.2.path', 'swagger-with-versions');
+        $app['config']->set('swagger-ui.files.1.path', 'swagger-with-versions');
+        $app['config']->set('swagger-ui.files.1.middleware', ['web']);
     }
 }


### PR DESCRIPTION
This PR adds support for multiple swagger files on different routes or multiple versions on the same route.
Key features are:
- multiple routes can be defined in the config
- middleware config per route
- multiple possible versions

This PR contains breaking changes due to the overhaul in the config file.