### PR TITLE
Add sub-path routes support

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -35,12 +35,12 @@
                     urls: [
                         @foreach ($data['versions'] as $version => $path)
                             {
-                                url: '{{ ltrim($data['path'], '/') . '/' . $version }}',
+                                url: '/{{ $data['path'] }}/{{ $version }}',
                                 name: '{{ $version }}',
                             },
                         @endforeach
                     ],
-                    "urls.primaryName": "{{$data['default']}}",
+                    "urls.primaryName": "{{ $data['default'] }}",
                     dom_id: '#swagger-ui',
                     deepLinking: true,
                     presets: [

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -13,7 +13,7 @@ class OpenApiJsonController
 {
     public function __invoke(Request $request, string $filename) : JsonResponse
     {
-        $path = $request->segment(1);
+        $path = implode('/', array_slice($request->segments(), 0, -1));
 
         try {
             $file = collect(config('swagger-ui.files'))->filter(function ($values) use ($filename, $path) {

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -108,7 +108,7 @@ class OpenApiRouteTest extends TestCase
     /** @test */
     public function it_returns_if_provided_path_does_have_sub_paths()
     {
-        $this->getJson('sub-path/swagger-with-versions/v1')
+        $this->getJson('path/with/multiple/segments/swagger-with-versions/v1')
             ->assertStatus(200);
     }
 

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -106,6 +106,13 @@ class OpenApiRouteTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_if_provided_path_does_have_sub_paths()
+    {
+        $this->getJson('sub-path/swagger-with-versions/v1')
+            ->assertStatus(200);
+    }
+
+    /** @test */
     public function it_returns_not_found_response_if_provided_version_does_not_exist_in_file()
     {
         $this->getJson('swagger/v4')

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -53,10 +53,10 @@ class SwaggerUiRouteTest extends TestCase
     /** @test */
     public function it_supports_multiple_versions_with_sub_path()
     {
-        $this->get('sub-path/swagger-with-versions')
+        $this->get('path/with/multiple/segments/swagger-with-versions')
             ->assertStatus(200)
-            ->assertSee('url: \'/sub-path/swagger-with-versions/v1\'', false)
-            ->assertSee('url: \'/sub-path/swagger-with-versions/v2\'', false);
+            ->assertSee('url: \'/path/with/multiple/segments/swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'/path/with/multiple/segments/swagger-with-versions/v2\'', false);
     }
 
     /** @test */

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -29,7 +29,7 @@ class SwaggerUiRouteTest extends TestCase
     {
         $this->get('swagger')
             ->assertStatus(200)
-            ->assertSee('url: \'swagger/v1\'', false);
+            ->assertSee('url: \'/swagger/v1\'', false);
     }
 
     /** @test */
@@ -42,12 +42,21 @@ class SwaggerUiRouteTest extends TestCase
     }
 
     /** @test */
-    public function it_supports_multiple_verions()
+    public function it_supports_multiple_versions()
     {
         $this->get('swagger-with-versions')
             ->assertStatus(200)
-            ->assertSee('url: \'swagger-with-versions/v1\'', false)
-            ->assertSee('url: \'swagger-with-versions/v2\'', false);
+            ->assertSee('url: \'/swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'/swagger-with-versions/v2\'', false);
+    }
+
+    /** @test */
+    public function it_supports_multiple_versions_with_sub_path()
+    {
+        $this->get('sub-path/swagger-with-versions')
+            ->assertStatus(200)
+            ->assertSee('url: \'/sub-path/swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'/sub-path/swagger-with-versions/v2\'', false);
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,7 +24,7 @@ abstract class TestCase extends BaseTestCase
             'v1' => __DIR__ . '/testfiles/openapi.json',
             'v2' => __DIR__ . '/testfiles/openapi-v2.json',
         ]);
-        $app['config']->set('swagger-ui.files.2.path', 'sub-path/swagger-with-versions');
+        $app['config']->set('swagger-ui.files.2.path', 'path/with/multiple/segments/swagger-with-versions');
         $app['config']->set('swagger-ui.files.2.middleware', ['web']);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,5 +18,13 @@ abstract class TestCase extends BaseTestCase
         ]);
         $app['config']->set('swagger-ui.files.1.path', 'swagger-with-versions');
         $app['config']->set('swagger-ui.files.1.middleware', ['web']);
+
+        $app['config']->set('swagger-ui.files.2', config('swagger-ui.files.0'));
+        $app['config']->set('swagger-ui.files.2.versions', [
+            'v1' => __DIR__ . '/testfiles/openapi.json',
+            'v2' => __DIR__ . '/testfiles/openapi-v2.json',
+        ]);
+        $app['config']->set('swagger-ui.files.2.path', 'sub-path/swagger-with-versions');
+        $app['config']->set('swagger-ui.files.2.middleware', ['web']);
     }
 }


### PR DESCRIPTION
This PR is the solution to ["Allow base path to contain multiple segments" issue](https://github.com/nextapps-be/laravel-swagger-ui/issues/22). It gives possibility to serve Swagger UI under non root path, eg. example.com/api/docs/api-name.