### PR TITLE
Give option to set validator URL

### DIFF
--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -33,7 +33,7 @@ return [
             /*
              * Specify the validator URL. If no URL provided, validation will not run
              */
-            'validation_url' => env('SWAGGER_UI_VALIDATION_URL', null),
+            'validator_url' => env('SWAGGER_UI_VALIDATOR_URL', null),
 
             /*
              * If enabled the file will be modified to set the server url and oauth urls.

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -33,7 +33,7 @@ return [
             /*
              * Specify the validator URL. If no URL provided, validation will not run
              */
-            'validator_url' => env('SWAGGER_UI_VALIDATOR_URL', null),
+            'validator_url' => env('SWAGGER_UI_VALIDATOR_URL'),
 
             /*
              * If enabled the file will be modified to set the server url and oauth urls.

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -31,7 +31,7 @@ return [
             ],
 
             /*
-             * Specify the validator URL. If no URL provided, validation will not run
+             * Specify the validator URL. Set to false to disable validation.
              */
             'validator_url' => env('SWAGGER_UI_VALIDATOR_URL'),
 

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -31,6 +31,11 @@ return [
             ],
 
             /*
+             * Specify the validator URL. If no URL provided, validation will not run
+             */
+            'validation_url' => env('SWAGGER_UI_VALIDATION_URL', null),
+
+            /*
              * If enabled the file will be modified to set the server url and oauth urls.
              */
             'modify_file' => true,

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,6 +52,7 @@
                         SwaggerUIStandalonePreset
                     ],
                     layout: 'StandaloneLayout',
+                    validationUrl: {{  $data["validation_url"] ?: "https://validator.swagger.io/validator" }}
                 });
 
                 ui.initOAuth({

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,7 +52,9 @@
                         SwaggerUIStandalonePreset
                     ],
                     layout: 'StandaloneLayout',
-                    validationUrl: {{  $data["validator_url"] ?: "https://validator.swagger.io/validator" }}
+                    @if (!is_null($data["validator_url"]))
+                        validatorUrl: '{{ $data["validator_url"] }}'
+                    @endif
                 });
 
                 ui.initOAuth({

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,7 +52,7 @@
                         SwaggerUIStandalonePreset
                     ],
                     layout: 'StandaloneLayout',
-                    validationUrl: {{  $data["validator_url"] ?: "https://validator.swagger.io/validator" }}
+                    validationUrl: {{  array_key_exists("validator_url", $data) && $data["validator_url"] ? $data["validator_url"] : "https://validator.swagger.io/validator" }}
                 });
 
                 ui.initOAuth({

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,7 +52,7 @@
                         SwaggerUIStandalonePreset
                     ],
                     layout: 'StandaloneLayout',
-                    validationUrl: {{  array_key_exists("validator_url", $data) && $data["validator_url"] ? $data["validator_url"] : "https://validator.swagger.io/validator" }}
+                    validationUrl: {{  $data["validator_url"] ?: "https://validator.swagger.io/validator" }}
                 });
 
                 ui.initOAuth({

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,7 +52,7 @@
                         SwaggerUIStandalonePreset
                     ],
                     layout: 'StandaloneLayout',
-                    validationUrl: {{  $data["validation_url"] ?: "https://validator.swagger.io/validator" }}
+                    validationUrl: {{  $data["validator_url"] ?: "https://validator.swagger.io/validator" }}
                 });
 
                 ui.initOAuth({


### PR DESCRIPTION
I am hosting my documentation behind basic HTTP auth so the validation always fail and it gives a red X for favicon and an invalid banner bottom of the page.

With this we have the ability to set custom validator URL or disable the validation by setting the URL to `false`.