### PR TITLE
fix: use full url for Swagger Ui bundles urls

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -39,7 +39,7 @@
                     urls: [
                         @foreach ($data['versions'] as $version => $path)
                             {
-                                url: '{{ url($data['path']) }}/{{ $version }}',
+                                url: '{{ url("{$data['path']}/{$version}") }}',
                                 name: '{{ $version }}',
                             },
                         @endforeach

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -39,7 +39,7 @@
                     urls: [
                         @foreach ($data['versions'] as $version => $path)
                             {
-                                url: '/{{ $data['path'] }}/{{ $version }}',
+                                url: '{{ url($data['path']) }}/{{ $version }}',
                                 name: '{{ $version }}',
                             },
                         @endforeach

--- a/tests/SwaggerUiRouteTest.php
+++ b/tests/SwaggerUiRouteTest.php
@@ -29,7 +29,7 @@ class SwaggerUiRouteTest extends TestCase
     {
         $this->get('swagger')
             ->assertStatus(200)
-            ->assertSee('url: \'/swagger/v1\'', false);
+            ->assertSee('url: \'http://localhost/swagger/v1\'', false);
     }
 
     /** @test */
@@ -46,8 +46,8 @@ class SwaggerUiRouteTest extends TestCase
     {
         $this->get('swagger-with-versions')
             ->assertStatus(200)
-            ->assertSee('url: \'/swagger-with-versions/v1\'', false)
-            ->assertSee('url: \'/swagger-with-versions/v2\'', false);
+            ->assertSee('url: \'http://localhost/swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'http://localhost/swagger-with-versions/v2\'', false);
     }
 
     /** @test */
@@ -55,8 +55,8 @@ class SwaggerUiRouteTest extends TestCase
     {
         $this->get('path/with/multiple/segments/swagger-with-versions')
             ->assertStatus(200)
-            ->assertSee('url: \'/path/with/multiple/segments/swagger-with-versions/v1\'', false)
-            ->assertSee('url: \'/path/with/multiple/segments/swagger-with-versions/v2\'', false);
+            ->assertSee('url: \'http://localhost/path/with/multiple/segments/swagger-with-versions/v1\'', false)
+            ->assertSee('url: \'http://localhost/path/with/multiple/segments/swagger-with-versions/v2\'', false);
     }
 
     /** @test */


### PR DESCRIPTION
Hello! I wanted to use your package on an application hosted in a subdirectory (like `https://example.net/my-laravel-application/`), but it failed to load the Swagger bundle because the link is generated from the root of the application.

This proposed change fixes this behaviour by using the `url()` helper to generate a fully qualified link to the openapi file.



<details>

<summary>I failed to add a unit test 😭 </summary>

I tried to add a unit test to test for this behaviour, but I couldn't get it to work correctly.
- By default, the `url()` helper doesn't use the config from `app.url` in the CLI (as far as I can say)
- So I added `URL::forceRootUrl(config('app.url'));`, but then the request gives a 404 as the test request now includes the subdir in it's path
- The last solution was to override the `prepareUrlForRequest()` method to remove the `url()` helper call from it, but I'm not keen to override a framework method. <small>It works though.</small>

```php

    /** @test */
    public function it_supports_application_sub_dir_and_swagger_sub_path()
    {
        config()->set('app.url', 'http://localhost/application-subdir/');

        // https://github.com/laravel/framework/issues/18613#issuecomment-342033733
        URL::forceRootUrl(config('app.url'));

        $this->assertEquals('http://localhost/application-subdir/path/with/multiple/segments/swagger-with-versions', url('path/with/multiple/segments/swagger-with-versions'));

        $this->get('/path/with/multiple/segments/swagger-with-versions')
            ->assertStatus(200)
            ->assertSee('url: \'http://localhost/application-subdir/path/with/multiple/segments/swagger-with-versions/v1\'', false)
            ->assertSee('url: \'http://localhost/application-subdir/path/with/multiple/segments/swagger-with-versions/v2\'', false);
    }

    /**
     * @overrides Do not use the `url()` helper, because the router doesn't use the setting from config('app.url')
     */
    protected function prepareUrlForRequest($uri)
    {
        if (str_starts_with($uri, '/')) {
            $uri = substr($uri, 1);
        }

        return trim($uri, '/');
    }
```
</details>